### PR TITLE
Fixed subfolder handling

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -22,10 +22,11 @@ function getOrCreateSubFolder(baseFolder,folderArray) {
   var nextFolderName = folderArray.shift();
   var nextFolder = null;
   var folders = baseFolder.getFolders();
-  for (var i=0; i<folders.length; i++) {
-    var folder = folders[i];
-    if (folders[i].getName() == nextFolderName) {
-      nextFolder = folders[i];
+  while (folders.hasNext()) {
+    folder = folders.next();
+    folderName = folder.getName();
+    if (folderName == nextFolderName){
+      nextFolder = folder;
       break;
     }
   }


### PR DESCRIPTION
Hello, 

my friend - @mazac85 just discovered issue related to get or create subfolder handling, when ``folder`` variable (containing subfolders) in config is changed. It creates new duplicate parent folder.

Somebody already mentioned it in upstream repo: https://github.com/ahochsteger/gmail2gdrive/issues/7

I am not  a javascript developer, but it works for me, so if you like the solution, I would be glad you merge this.